### PR TITLE
Order cells based on principal graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+#extras
+data/
+datasets/

--- a/extras/run/precompute/monocle3.r
+++ b/extras/run/precompute/monocle3.r
@@ -60,7 +60,7 @@ kmean_res <- tryCatch({
 cds <- learn_graph(cds)
 
 # Order cells
-cds <- order_cells(cds, root_cells=barcodes[1])
+cds <- order_cells(cds, root_cells=barcodes[length(barcodes) %/% 2 + 1])
 
 # Write results
 principal_graph_aux <- cds@principal_graph_aux@listData$UMAP
@@ -82,4 +82,23 @@ h5write(
 h5write(
   kmean_res$cluster,
   file=data.path, name="monocle3/k_means_clustering"
+)
+
+principal_graph <- principal_graph_aux$stree
+h5createGroup(data.path,"monocle3/principal_graph")
+h5write(
+  principal_graph@x, file=data.path,
+  name="monocle3/principal_graph/data"
+)
+h5write(
+  principal_graph@i, file=data.path,
+  name="monocle3/principal_graph/indices"
+)
+h5write(
+  principal_graph@p, file=data.path,
+  name="monocle3/principal_graph/indptr"
+)
+h5write(
+  principal_graph@Dim, file=data.path,
+  name="monocle3/principal_graph/shape"
 )

--- a/extras/run/test/test_pseudotime.py
+++ b/extras/run/test/test_pseudotime.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import h5py
+import numpy as np
 from py_monocle import pseudotime
 from scipy.stats import kendalltau
 
@@ -18,7 +19,12 @@ def test_pseudotime(data_id: str):
     matrix=matrix,
     clusters=clusters,
     use_clusters_as_kmeans=True,
-    root_cells=0,
+    root_cells=matrix.shape[0] // 2,
   )
+
+  diffs = abs(ptime - expected_pseudotime) / np.max(expected_pseudotime)
+  max_diff = np.max(diffs)
+  assert  max_diff < 0.1, f"Max ratio difference is {max_diff}."
+
   score = kendalltau(ptime, expected_pseudotime)[0]
   assert score > 0.95, f"The similarity is {score}."

--- a/py_monocle/__init__.py
+++ b/py_monocle/__init__.py
@@ -93,6 +93,7 @@ def pseudotime(
     matrix,
     projected_points,
     centroids,
+    mst,
     root_cells=root_cells,
     root_pr_cells=root_pr_cells,
   )

--- a/py_monocle/_order_cells.py
+++ b/py_monocle/_order_cells.py
@@ -1,15 +1,17 @@
-import numpy as np
 from typing import Union, Optional
 import numpy as np
-from scipy.sparse.csgraph import dijkstra
+import pandas as pd
+from scipy import sparse
+import networkx as nx
 
-from ._utils import minimum_spanning_tree, find_nearest_principal_nodes
+from ._utils import find_nearest_principal_nodes, find_nearest_principal_edges
 
 
 def order_cells(
     matrix: np.ndarray,
     projected_points: np.ndarray,
     centroids: np.ndarray,
+    mst: sparse.csr_matrix,
     root_cells: Optional[Union[int, np.ndarray]] = None,
     root_pr_cells: Optional[Union[int, np.ndarray]] = None,
 ):
@@ -24,6 +26,8 @@ def order_cells(
     Projected points of matrix onto the principal graph.
   centroids : ``ndarray``
     The centroids of the principal graph.
+  mst : ``csr_matrix``
+    The symmetrical minimum spanning tree of the principal graph.
   root_cells : ``Optional[Union[int, np.ndarray]]``, default: None
     (List) index of the expression matrix.
   root_pr_cells : ``Optional[Union[int, np.ndarray]]``, default: None
@@ -44,6 +48,56 @@ def order_cells(
     centroids[root_pr_cells].reshape((-1, 2)), matrix
   )
 
-  mst = minimum_spanning_tree(projected_points)
-  pseudotime = dijkstra(mst, directed=False, indices=root_cells)
-  return np.min(pseudotime, axis=0)
+  # Find connection of each nearest edge
+  nearest_edges = find_nearest_principal_edges(
+    matrix, centroids, mst
+  )
+  first_nodes = np.minimum(*nearest_edges)
+  second_nodes = np.maximum(*nearest_edges)
+  edge_group = first_nodes * len(centroids) + second_nodes
+  distances = np.sqrt(np.sum(
+    np.square(centroids[first_nodes] - projected_points), axis=1))
+  df = pd.DataFrame({
+    "cell_id": np.arange(len(matrix)),
+    "root": first_nodes + len(matrix),
+    "group": edge_group,
+    "distances": distances,
+  })
+  sort_df = df.sort_values(["group", "distances"]).groupby("group")
+  heads = sort_df["cell_id"].head(-1)
+  tails = sort_df["cell_id"].tail(-1)
+  df.iloc[tails, df.columns.get_loc("root")] = heads
+  df.iloc[tails, df.columns.get_loc("distances")] -= \
+    df.iloc[heads, df.columns.get_loc("distances")].to_numpy()
+  del df["group"]
+
+  # Add connection of last nodes in group to second node on their nearest edges
+  end_traces = sort_df["cell_id"].tail(1).to_numpy()
+  end_nodes = second_nodes[end_traces]
+  distances = np.sqrt(np.sum(
+    np.square(centroids[end_nodes] - projected_points[end_traces]), axis=1))
+  end_nodes += len(matrix)
+  df = pd.concat((df,
+                  pd.DataFrame({
+                    "cell_id": end_traces,
+                    "root": end_nodes,
+                    "distances": distances,
+                  })
+  ))
+
+  # Add connection of minimum spanning tree of the principal graph.
+  principal_edges = mst.nonzero()
+  df = pd.concat((df,
+                  pd.DataFrame({
+                    "cell_id": principal_edges[0] + len(matrix),
+                    "root": principal_edges[1] + len(matrix),
+                    "distances": mst.data,
+                  })
+  ))
+
+  graph = nx.Graph()
+  graph.add_weighted_edges_from(df.to_numpy())
+
+  pseudotime = nx.multi_source_dijkstra_path_length(
+    graph, sources=set(root_cells), weight="weight")
+  return np.array([pseudotime.get(i, np.inf) for i in range(len(matrix))])


### PR DESCRIPTION
- Optimize order_cells: order cells based on principal graph without rebuilding the minimum spanning tree.